### PR TITLE
Add source line to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
+source :rubygems
 gem "rake"
 gem "rspec", ">=2.0"


### PR DESCRIPTION
This placates later versions of Bundler that don't assume rubygems.org as the source.
