### PR TITLE
Fix typo in Simon Says exercise

### DIFF
--- a/03_simon_says/simon_says_spec.rb
+++ b/03_simon_says/simon_says_spec.rb
@@ -89,7 +89,7 @@ describe "Simon says" do
     end
 
     it "does capitalize 'little words' at the start of a title" do
-      titleize("the bridge over the river kwai").should == "The Bridge over the River Kwai"
+      titleize("the bridge over the river kwai").should == "The Bridge Over the River Kwai"
     end
   end
 


### PR DESCRIPTION
The correct title capitalization should be "The Bridge Over the River Kwai." The word "over" was not capitalized in the test. THIS IS MY FIRST PULL REQUEST OMG!
