### PR TITLE
Removed first line in RakeFile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 # This Rakefile has all the right settings to run the tests inside each lab
-gem 'rspec', '~>2'
 require 'rspec/core/rake_task'
 
 task :default => :spec


### PR DESCRIPTION
Gem install rspec installs rspec version 3.0.0 now, so the first line is unnecessary if already installed. In fact, it seems to create problems for those who have recently installed rspec version 3.0.0, hence the line removal.
