### PR TITLE
It´s modified to use RSpect 3.0.0 version (last) and two syntax ( ":should" & ":expect" ) inside our test 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 # This Rakefile has all the right settings to run the tests inside each lab
-gem 'rspec', '~>2'
+
+# Little file edition to use RSpec 3.0.0 version ( last )
+gem 'rspec', '~>3'  # Use '~>2' to downgrade
+
 require 'rspec/core/rake_task'
 
 task :default => :spec

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@ Write and class and do some basic math.</li>
 <li><p>Include version numbers:</p>
 
 <pre><code> $ ruby -v
- ruby 1.8.6 (2008-08-11 patchlevel 287) [universal-darwin9.0]
+ ruby 2.0.0p451 (2014-02-24 revision 45167) [universal.x86_64-darwin13]
 </code></pre></li>
 <li><p>Note where you have already looked for an answer</p></li>
 <li>If you can, include code snippets that reproduce the problem in isolation</li>

--- a/rspec_config.rb
+++ b/rspec_config.rb
@@ -1,4 +1,11 @@
-RSpec.configure do |c|
-  c.fail_fast = true
-  c.color = true
+RSpec.configure do |config|
+    config.fail_fast = true
+    config.color = true
+
+    # Modified to deactivate warnings about :should syntax
+    config.expect_with :rspec do |c|
+        
+        # Let´s use two syntaxs inside our tests
+        c.syntax = [:should, :expect]
+    end
 end


### PR DESCRIPTION
Use RSpec 3.0.0 version and more...

It´s modified to disable warnings about old ":should" syntax in RSpect 3.0.0 version and

to let´s us use two syntaxs ( ":should" & ":expect" ) inside our tests
