### PR TITLE
Escape the file path passed to rspec_opts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,6 @@ desc "run tests for this lab"
 RSpec::Core::RakeTask.new do |task|
   lab = Rake.application.original_dir
   task.pattern = "#{lab}/*_spec.rb"
-  task.rspec_opts = [ "-I#{lab}", "-I#{lab}/solution", '-f documentation', '-r ./rspec_config']
+  task.rspec_opts = [ "-I#{Shellwords.escape(lab)}", "-I#{Shellwords.escape(lab)}/solution", '-f documentation', '-r ./rspec_config']
   task.verbose = false
 end


### PR DESCRIPTION
Students in my class were getting errors if any directory in their absolute path contained spaces, `Shellwords.escape` will prevent any spaces or other odd characters from confusing the `-I` opt.
